### PR TITLE
genome_updater version 0.2.3

### DIFF
--- a/genome_updater.sh
+++ b/genome_updater.sh
@@ -117,6 +117,9 @@ get_assembly_summary() # parameter: ${1} assembly_summary file, ${2} database, $
 
 filter_assembly_summary() # parameter: ${1} assembly_summary file - return number of lines
 {
+    # Filter entries with "na" on url field
+    awk -F "\t" '$20!="na" {print $0}' "${1}" > "${1}_filtered"
+    mv "${1}_filtered" "${1}"
     if [[ "${refseq_category}" != "all" || "${assembly_level}" != "all" ]]
     then
         awk -F "\t" -v refseq_category="${refseq_category}" -v assembly_level="${assembly_level}" 'BEGIN{if(refseq_category=="all") refseq_category=".*"; if(assembly_level=="all") assembly_level=".*"} $5 ~ refseq_category && $12 ~ assembly_level && $11=="latest" {print $0}' "${1}" > "${1}_filtered"
@@ -612,7 +615,7 @@ if [[ "${MODE}" == "NEW" ]]; then
     fi
 
     filtered_lines=$(filter_assembly_summary "${new_assembly_summary}")
-    echolog " - $((all_lines-filtered_lines))/${all_lines} entries removed [RefSeq category: ${refseq_category}, Assembly level: ${assembly_level}, Version status: latest]" "1"
+    echolog " - $((all_lines-filtered_lines))/${all_lines} entries removed. Filters: RefSeq category =  ${refseq_category}, Assembly level = ${assembly_level}, Version status = latest, valid URL" "1"
     echolog " - ${filtered_lines} entries available" "1"
     
     if [ "${just_check}" -eq 1 ]; then
@@ -706,7 +709,7 @@ else # update/fix
         echolog "Downloading assembly summary [${new_label}]" "1"
         all_lines=$(get_assembly_summary "${new_assembly_summary}" "${database}" "${organism_group}")
         filtered_lines=$(filter_assembly_summary "${new_assembly_summary}")
-        echolog " - $((all_lines-filtered_lines))/${all_lines} entries removed [RefSeq category: ${refseq_category}, Assembly level: ${assembly_level}, Version status: latest]" "1"
+        echolog " - $((all_lines-filtered_lines))/${all_lines} entries removed. Filters: RefSeq category =  ${refseq_category}, Assembly level = ${assembly_level}, Version status = latest, valid URL" "1"
         echolog " - ${filtered_lines} entries available" "1"
         echolog "" "1"
         

--- a/genome_updater.sh
+++ b/genome_updater.sh
@@ -25,12 +25,13 @@ IFS=$' '
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-version="0.2.2"
+version="0.2.3"
 
 wget_tries=${wget_tries:-3}
 wget_timeout=${wget_timeout:-120}
 export wget_tries wget_timeout
-#export LC_NUMERIC="en_US.UTF-8"
+# Export locale numeric to avoid errors on printf in different setups
+export LC_NUMERIC="en_US.UTF-8"
 
 #activate aliases in the script
 shopt -s expand_aliases
@@ -62,7 +63,7 @@ count_lines_file(){ # parameter: ${1} file - return number of lines
 parse_new_taxdump() # parameter: ${1} taxids - return all taxids on of provided taxids
 {
 	taxids=${1}
-	echolog "Downloading taxdump and generating lineage" "0"
+	echolog "Downloading taxdump and generating lineage" "1"
     tmp_new_taxdump="${target_output_prefix}new_taxdump.tar.gz"
     tmp_taxidlineage="${working_dir}taxidlineage.dmp"
     get_new_taxdump "${tmp_new_taxdump}"

--- a/genome_updater.sh
+++ b/genome_updater.sh
@@ -265,8 +265,8 @@ remove_files() # parameter: ${1} file, ${2} fields [assembly_accesion,url] OR fi
 
 check_missing_files() # ${1} file, ${2} fields [assembly_accesion,url], ${3} extension - returns assembly accession, url and filename
 {
-    # Just returns if file doens't exist or if it's zero size
-    list_files ${1} ${2} ${3} | xargs --no-run-if-empty -n3 sh -c 'if [ ! -s "'"${target_output_prefix}${files_dir}"'${2}" ]; then echo "${0}\\t${1}\\t${2}"; fi'
+    # Just returns if file doesn't exist or if it's zero size
+    list_files ${1} ${2} ${3} | xargs --no-run-if-empty -n3 sh -c 'if [ ! -s "'"${target_output_prefix}${files_dir}"'${2}" ]; then echo "${0}'$'\t''${1}'$'\t''${2}"; fi'
 }
 
 check_complete_record() # parameters: ${1} file, ${2} field [assembly accession, url], ${3} extension - returns assembly accession, url

--- a/genome_updater.sh
+++ b/genome_updater.sh
@@ -103,13 +103,13 @@ get_assembly_summary() # parameter: ${1} assembly_summary file, ${2} database, $
         fi
     done
 
-    # Keep only selected species or taxid lineage
+    # Keep only selected species or taxid lineage, removing at the end duplicated entries from duplicates on taxids
     if [[ ! -z "${species}" ]]; then
-        join -1 7 -2 1 <(sort -k 7,7 "${1}") <(echo "${species//,/$'\n'}" | sort -k 1,1) -t$'\t' -o "1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,1.10,1.11,1.12,1.13,1.14,1.15,1.16,1.17,1.18,1.19,1.20,1.21,1.22" > "${1}_species"
+        join -1 7 -2 1 <(sort -k 7,7 "${1}") <(echo "${species//,/$'\n'}" | sort -k 1,1) -t$'\t' -o "1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,1.10,1.11,1.12,1.13,1.14,1.15,1.16,1.17,1.18,1.19,1.20,1.21,1.22" | sort | uniq > "${1}_species"
         mv "${1}_species" "${1}"
     elif [[ ! -z "${taxids}" ]]; then
     	lineage_taxids=$(parse_new_taxdump "${taxids}")
-        join -1 6 -2 1 <(sort -k 6,6 "${1}") <(echo "${lineage_taxids//,/$'\n'}" | sort -k 1,1) -t$'\t' -o "1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,1.10,1.11,1.12,1.13,1.14,1.15,1.16,1.17,1.18,1.19,1.20,1.21,1.22" > "${1}_taxids"
+        join -1 6 -2 1 <(sort -k 6,6 "${1}") <(echo "${lineage_taxids//,/$'\n'}" | sort -k 1,1) -t$'\t' -o "1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,1.10,1.11,1.12,1.13,1.14,1.15,1.16,1.17,1.18,1.19,1.20,1.21,1.22" | sort | uniq > "${1}_taxids"
         mv "${1}_taxids" "${1}"
     fi
     count_lines_file "${1}"

--- a/tests/assembly_summary_na_url.txt
+++ b/tests/assembly_summary_na_url.txt
@@ -1,0 +1,2 @@
+GCF_000226095.1	PRJNA79339	SAMN00739435		representative genome	573729	78579	Thermothelomyces thermophilus ATCC 42464	strain=ATCC 42464		latest	Complete Genome	Major	Full	2011/09/16	ASM22609v1	DOE Joint Genome Institute	GCA_000226095.1	identical	na		
+GCF_013368755.1	PRJNA645155	SAMN15229550		representative genome	121627	121627	Talaromyces rugulosus	strain=W13939		latest	Complete Genome	Major	Full	2020/06/23	ASM1336875v1	Xi'an Jiaotong University	GCA_013368755.1	identical	ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/013/368/755/GCF_013368755.1_ASM1336875v1		

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -2,28 +2,6 @@
 set -euxo pipefail
 rm -rf tests/tst_*
 threads=${1:-1}
-####################### Basic tests
-
-# Download
-out_direct="tests/tst_fungi_refseq_cg"
-out_mod="tests/tst_fungi_refseq_cg_mod"
-./genome_updater.sh -o "${out_direct}" -f "assembly_report.txt" -g "fungi" -d "refseq" -l "Complete Genome" -u -r -p -m -b v1 -t ${threads}
-# Donwload with external assembly summary (outdated entry, extra entries, deleted entries)
-./genome_updater.sh -o "${out_mod}" -f "assembly_report.txt" -g "fungi" -d "refseq" -l "Complete Genome" -u -r -p -m -b v1 -e tests/assembly_summary_fungi_refseq_cg_mod.txt -t ${threads}
-# Fix + Update (modified to the "standard")
-find "${out_mod}"/v1/files/ -xtype f | shuf -n 2 | xargs rm
-touch "${out_mod}"/v1/files/random_file_1
-touch "${out_mod}"/v1/files/random_file_2
-./genome_updater.sh -o "${out_mod}" -f "assembly_report.txt" -g "fungi" -d "refseq" -l "Complete Genome" -u -r -p -m -b v2 -x -t ${threads}
-
-# Fix (delete random files)
-find "${out_mod}"/v2/files/ -xtype f | shuf -n 2 | xargs rm
-./genome_updater.sh -o "${out_mod}" -f "assembly_report.txt" -i -u -r -p -m -t ${threads}
-
-# Comparisons
-diff <(sort "${out_direct}"/v1/updated_assembly_accession.txt) <(sort "${out_mod}"/v2/updated_assembly_accession.txt)
-diff <(sort "${out_direct}"/v1/updated_sequence_accession.txt) <(sort "${out_mod}"/v2/updated_sequence_accession.txt)
-diff <(find "${out_direct}"/v1/files/ -xtype f -printf "%f\n" | sort) <(find "${out_mod}"/v2/files/ -xtype f -printf "%f\n" | sort )
 
 ####################### All fail
 out_fail="tests/tst_failed"
@@ -35,6 +13,35 @@ test $(cat "${out_fail}/v1/"*_url_failed.txt | wc -l) -eq 2
 # and none as successful
 test $(cat "${out_fail}/v1/"*_url_downloaded.txt | wc -l) -eq 0
 
+####################### na on URL
+out_na="tests/tst_na_url"
+./genome_updater.sh -o "${out_na}" -e "tests/assembly_summary_na_url.txt" -m -b v1 -t ${threads} -p
+# should download only one out of 2 files
+test $(find "${out_na}/v1/files/" -xtype f | wc -l) -eq 1
+# test if nothing failed (it should not even be attempted to download, removed in filter step)
+test $(cat "${out_na}/v1/"*_url_failed.txt | wc -l) -eq 0
+# and one successful
+test $(cat "${out_na}/v1/"*_url_downloaded.txt | wc -l) -eq 1
+
+####################### Basic tests
+# Download
+out_direct="tests/tst_fungi_refseq_cg"
+out_mod="tests/tst_fungi_refseq_cg_mod"
+./genome_updater.sh -o "${out_direct}" -f "assembly_report.txt" -g "fungi" -d "refseq" -l "Complete Genome" -u -r -p -m -b v1 -t ${threads}
+# Donwload with external assembly summary (outdated entry, extra entries, deleted entries)
+./genome_updater.sh -o "${out_mod}" -f "assembly_report.txt" -g "fungi" -d "refseq" -l "Complete Genome" -u -r -p -m -b v1 -e "tests/assembly_summary_fungi_refseq_cg_mod.txt" -t ${threads}
+# Fix + Update (modified to the "standard")
+find "${out_mod}"/v1/files/ -xtype f | shuf -n 2 | xargs rm
+touch "${out_mod}"/v1/files/random_file_1
+touch "${out_mod}"/v1/files/random_file_2
+./genome_updater.sh -o "${out_mod}" -f "assembly_report.txt" -g "fungi" -d "refseq" -l "Complete Genome" -u -r -p -m -b v2 -x -t ${threads}
+# Fix (delete random files)
+find "${out_mod}"/v2/files/ -xtype f | shuf -n 2 | xargs rm
+./genome_updater.sh -o "${out_mod}" -f "assembly_report.txt" -i -u -r -p -m -t ${threads}
+# Comparisons
+diff <(sort "${out_direct}"/v1/updated_assembly_accession.txt) <(sort "${out_mod}"/v2/updated_assembly_accession.txt)
+diff <(sort "${out_direct}"/v1/updated_sequence_accession.txt) <(sort "${out_mod}"/v2/updated_sequence_accession.txt)
+diff <(find "${out_direct}"/v1/files/ -xtype f -printf "%f\n" | sort) <(find "${out_mod}"/v2/files/ -xtype f -printf "%f\n" | sort )
 
 ####################### Species tests
 # Species tests (genbank)
@@ -49,6 +56,16 @@ out_2="tests/tst_species64571"
 diff <(find "${out_all}"/v1/files/ -xtype f -printf "%f\n" | sort) <(find "${out_1}"/v1/files/ "${out_2}"/v1/files/ -xtype f  -printf "%f\n" | sort)
 
 
+####################### duplicated entries 
+out_dup1="tests/tst_duplicated1"
+out_dup2="tests/tst_duplicated2"
+./genome_updater.sh -o "${out_dup1}" -g "species:1686310" -m -b v1 -t ${threads} -p -u -r 
+./genome_updater.sh -o "${out_dup2}" -g "species:1686310,1686310,1686310" -m -b v1 -t ${threads} -p -u -r 
+# number of output files and reports should be the same
+test $(find "${out_dup1}/v1/files/" -xtype f | wc -l) -eq $(find "${out_dup2}/v1/files/" -xtype f | wc -l)
+diff <(sort "${out_dup1}"/v1/updated_assembly_accession.txt) <(sort "${out_dup2}"/v1/updated_assembly_accession.txt)
+diff <(sort "${out_dup1}"/v1/updated_sequence_accession.txt) <(sort "${out_dup2}"/v1/updated_sequence_accession.txt)
+
 ####################### Taxid tests
 # Taxids tests (multi file)
 out_all="tests/tst_taxids"
@@ -62,4 +79,9 @@ out_2="tests/tst_taxids2493627"
 diff <(find "${out_all}"/v1/files/ -xtype f -printf "%f\n" | sort) <(find "${out_1}"/v1/files/ "${out_2}"/v1/files/ -xtype f  -printf "%f\n" | sort)
 
 echo ""
+echo ""
+echo ""
+echo "*******************************"
 echo "All tests finished successfully"
+echo "*******************************"
+echo ""

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -61,6 +61,5 @@ out_2="tests/tst_taxids2493627"
 # check if both runs have the same files
 diff <(find "${out_all}"/v1/files/ -xtype f -printf "%f\n" | sort) <(find "${out_1}"/v1/files/ "${out_2}"/v1/files/ -xtype f  -printf "%f\n" | sort)
 
-
 echo ""
 echo "All tests finished successfully"


### PR DESCRIPTION
- export LC_NUMERIC="en_US.UTF-8" to avoid printf numeric error
- change syntax to print tab inside sh call and improve support in other systems
- fix bugs on repeated taxids/species, na on URL
- tests added