### PR TITLE
Feature/reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Some days later, update the repository:
 genome_updater downloads and keeps several snapshots of a certain sub-set of the genomes repository, without redundancy and with incremental track of changes.
 
 - it runs on a working directory (defined with `-o`) and creates a snapshot (optionally named with `-b`, timestamp by default) of refseq and/or genbank (`-d`) genome repositories based on selected organism groups (`-g`) and/or taxonomic ids (`-T`) with the desired files type(s) (`-f`)
-- filters can be applied to refine the selection: refseq category (`-c`), assembly level (`-l`), dates (`-D`/`-E`), custom filters (`-F`), top assemblies (`-A`)
+- filters can be applied to refine the selection: refseq category (`-c`), assembly level (`-l`), dates (`-D`/`-E`), custom filters (`-F`), [top assemblies](#Top-assemblies) (`-A`)
 - `-M gtdb` enables GTDB [3] compability. Only assemblies from the latest GTDB release will be kept and taxonomic filters will work based on GTDB nodes (e.g. `-T "c__Hydrothermarchaeia"` or `-A genus:3`)
 - the repository can be updated or changed with incremental changes. outdated files are kept in their respective version and repeated files linked to the new version. genome_updater keepts track of all changes and just downloads what is necessary
 
@@ -136,7 +136,7 @@ To test if all genome_updater functions are running properly on your system:
 
 ### assembly accessions
 
-The parameter `-u` activates the output of a list of updated assembly accessions for the entries with all files (`-f`) successfully downloaded. The file `updated_assembly_accession.txt` has the following fields (tab separated):
+The parameter `-u` activates the output of a list of updated assembly accessions for the entries with all files (`-f`) successfully downloaded. The file `{timestamp}_assembly_accession.txt` has the following fields (tab separated):
 
 	Added [A] or Removed [R], assembly accession, url
 
@@ -148,7 +148,7 @@ Example:
 
 ### sequence accessions
 
-The parameter `-r` activates the output of a list of updated sequence accessions for the entries with all files (`-f`) successfully downloaded. It is only available when `assembly_report.txt` is one of the file types. The file `updated_sequence_accession.txt` has the following fields (tab separated):
+The parameter `-r` activates the output of a list of updated sequence accessions for the entries with all files (`-f`) successfully downloaded. It is only available when `assembly_report.txt` is one of the file types. The file `{timestamp}_sequence_accession.txt` has the following fields (tab separated):
 
 	Added [A] or Removed [R], assembly accession, genbank accession, refseq accession, sequence length, taxonomic id
 
@@ -156,8 +156,6 @@ Example:
 
 	A	GCA_000243255.1	CM001436.1	NZ_CM001436.1	3200946	937775
 	R	GCA_000275865.1	CM001555.1	NZ_CM001555.1	2475100	28892
-
-* genome_updater fixes the current version of the database before updating (or just fix with `-i`). In this step if some entry is fixed and the reports are active, all lines are going to be reported as Added.
 
 ### URLs (and files)
 
@@ -173,7 +171,7 @@ or
 
 ## Top assemblies
 
-`-A` will try to selected the "best" assemblies for each leaf taxonomic nodes or a specific rank based on 4 categories (A-D), in the following order of importance:
+`-A` will selected the "best" assemblies for each taxonomic nodes (leaves or specific rank) according to 4 categories (A-D), in the following order of importance:
 
 	A) refseq Category: 
 		1) reference genome

--- a/genome_updater.sh
+++ b/genome_updater.sh
@@ -1274,15 +1274,18 @@ if [[ "${MODE}" == "NEW" ]]; then
             echolog "Downloading $((filtered_lines*(n_formats+1))) files with ${threads} threads" "1"
             download_files "${new_assembly_summary}" "1,20" "${file_formats}"
             echolog "" "1"
-            # UPDATED INDICES assembly accession
+
             if [ "${updated_assembly_accession}" -eq 1 ]; then 
-                output_assembly_accession "${new_assembly_summary}" "1,20" "${file_formats}" "A" > "${new_output_prefix}updated_assembly_accession.txt"
-                echolog "Assembly accession report written [${new_output_prefix}updated_assembly_accession.txt]" "1"
+                echolog "Writing assembly accession report" "1"
+                output_assembly_accession "${new_assembly_summary}" "1,20" "${file_formats}" "A" > "${new_output_prefix}${timestamp}_assembly_accession.txt"
+                echolog " - ${new_output_prefix}${timestamp}_assembly_accession.txt" "1"
+                echolog "" "1"
             fi
-            # UPDATED INDICES sequence accession
             if [ "${updated_sequence_accession}" -eq 1 ]; then
-                output_sequence_accession "${new_assembly_summary}" "1,20" "${file_formats}" "A" "${new_assembly_summary}" > "${new_output_prefix}updated_sequence_accession.txt"
-                echolog "Sequence accession report written [${new_output_prefix}updated_sequence_accession.txt]" "1"
+                echolog "Writing sequence accession report" "1"
+                output_sequence_accession "${new_assembly_summary}" "1,20" "${file_formats}" "A" "${new_assembly_summary}" > "${new_output_prefix}${timestamp}_sequence_accession.txt"
+                echolog " - ${new_output_prefix}${timestamp}_sequence_accession.txt" "1"
+                echolog "" "1"
             fi
         fi
     fi
@@ -1310,14 +1313,16 @@ else # update/fix
             echolog "" "1"
             # if new files were downloaded, rewrite reports (overwrite information on Removed accessions - all become Added)
             if [ "${updated_assembly_accession}" -eq 1 ]; then 
-                output_assembly_accession "${current_assembly_summary}" "1,20" "${file_formats}" "A" > "${current_output_prefix}updated_assembly_accession.txt"
-                echolog "Assembly accession report rewritten [${current_output_prefix}updated_assembly_accession.txt]" "1"
-                echolog " - In fix mode, all entries are report as 'A' (Added)" "1"
+                echolog "Writing assembly accession report" "1"
+                output_assembly_accession "${missing}" "1,2" "${file_formats}" "A" > "${current_output_prefix}${timestamp}_assembly_accession.txt"
+                echolog " - ${current_output_prefix}${timestamp}_assembly_accession.txt" "1"
+                echolog "" "1"
             fi
             if [ "${updated_sequence_accession}" -eq 1 ]; then
-                output_sequence_accession "${current_assembly_summary}" "1,20" "${file_formats}" "A" "${current_assembly_summary}" > "${current_output_prefix}updated_sequence_accession.txt"
-                echolog "Sequence accession report rewritten [${current_output_prefix}updated_sequence_accession.txt]" "1"
-                echolog " - In fix mode, all entries are report as 'A' (Added)" "1"
+                echolog "Writing sequence accession report" "1"
+                output_sequence_accession "${missing}" "1,2" "${file_formats}" "A" "${current_assembly_summary}" > "${current_output_prefix}${timestamp}_sequence_accession.txt"
+                echolog " - ${current_output_prefix}${timestamp}_sequence_accession.txt" "1"
+                echolog "" "1"
             fi
         fi
     else
@@ -1395,7 +1400,7 @@ else # update/fix
             echolog "Linking versions [${current_label} --> ${new_label}]" "1"
             # Only link existing files relative to the current version
             list_files "${current_assembly_summary}" "1,20" "${file_formats}" | cut -f 3 | xargs -P "${threads}" -I{} bash -c 'if [[ -f '"${current_output_prefix}${files_dir}{}"' ]]; then ln -s -r '"${current_output_prefix}${files_dir}{}"' '"${new_output_prefix}${files_dir}"'; fi'
-            echolog " - Done." "1"
+            echolog " - Done" "1"
             echolog "" "1"
             # set version - update default assembly summary
             echolog "Setting-up new version [${new_label}]" "1"
@@ -1403,19 +1408,19 @@ else # update/fix
             ln -s -r "${new_assembly_summary}" "${default_assembly_summary}"
             # Add entry on history
             write_history ${current_label} ${new_label} ${timestamp} ${new_assembly_summary}
-            echolog " - Done." "1"
+            echolog " - Done" "1"
             echolog "" "1"
 
             # UPDATED INDICES assembly accession
             if [ "${updated_assembly_accession}" -eq 1 ]; then 
-                output_assembly_accession "${update}" "3,4" "${file_formats}" "R" > "${new_output_prefix}updated_assembly_accession.txt"
-                output_assembly_accession "${remove}" "1,2" "${file_formats}" "R" >> "${new_output_prefix}updated_assembly_accession.txt"
+                output_assembly_accession "${update}" "3,4" "${file_formats}" "R" > "${new_output_prefix}${timestamp}_assembly_accession.txt"
+                output_assembly_accession "${remove}" "1,2" "${file_formats}" "R" >> "${new_output_prefix}${timestamp}_assembly_accession.txt"
             fi
             # UPDATED INDICES sequence accession (removed entries - do it before deleting them)
             if [ "${updated_sequence_accession}" -eq 1 ]; then
                 # current_assembly_summary is the old summary
-                output_sequence_accession "${update}" "3,4" "${file_formats}" "R" "${current_assembly_summary}" > "${new_output_prefix}updated_sequence_accession.txt"
-                output_sequence_accession "${remove}" "1,2" "${file_formats}" "R" "${current_assembly_summary}" >> "${new_output_prefix}updated_sequence_accession.txt"
+                output_sequence_accession "${update}" "3,4" "${file_formats}" "R" "${current_assembly_summary}" > "${new_output_prefix}${timestamp}_sequence_accession.txt"
+                output_sequence_accession "${remove}" "1,2" "${file_formats}" "R" "${current_assembly_summary}" >> "${new_output_prefix}${timestamp}_sequence_accession.txt"
             fi
             
             # Execute updates
@@ -1438,20 +1443,24 @@ else # update/fix
                 echolog " - NEW: Downloading $((new_lines*(n_formats+1))) files with ${threads} threads"    "1"
                 download_files "${new}" "1,2" "${file_formats}"
             fi 
-            echolog " - Done." "1"
+            echolog " - Done" "1"
             echolog "" "1"
 
             # UPDATED INDICES assembly accession (added entries - do it after downloading them)
             if [ "${updated_assembly_accession}" -eq 1 ]; then 
-                output_assembly_accession "${update}" "1,2" "${file_formats}" "A" >> "${new_output_prefix}updated_assembly_accession.txt"
-                output_assembly_accession "${new}" "1,2" "${file_formats}" "A" >> "${new_output_prefix}updated_assembly_accession.txt"
-                echolog "Assembly accession report written [${new_output_prefix}updated_assembly_accession.txt]" "1"
+                echolog "Writing assembly accession report" "1"
+                output_assembly_accession "${update}" "1,2" "${file_formats}" "A" >> "${new_output_prefix}${timestamp}_assembly_accession.txt"
+                output_assembly_accession "${new}" "1,2" "${file_formats}" "A" >> "${new_output_prefix}${timestamp}_assembly_accession.txt"
+                echolog " - ${new_output_prefix}${timestamp}_assembly_accession.txt" "1"
+                echolog "" "1"
             fi
             # UPDATED INDICES sequence accession (added entries - do it after downloading them)
             if [ "${updated_sequence_accession}" -eq 1 ]; then
-                output_sequence_accession "${update}" "1,2" "${file_formats}" "A" "${new_assembly_summary}">> "${new_output_prefix}updated_sequence_accession.txt"
-                output_sequence_accession "${new}" "1,2" "${file_formats}" "A" "${new_assembly_summary}" >> "${new_output_prefix}updated_sequence_accession.txt"
-                echolog "Sequence accession report written [${new_output_prefix}updated_sequence_accession.txt]" "1"
+                echolog "Writing sequence accession report" "1"
+                output_sequence_accession "${update}" "1,2" "${file_formats}" "A" "${new_assembly_summary}">> "${new_output_prefix}${timestamp}_sequence_accession.txt"
+                output_sequence_accession "${new}" "1,2" "${file_formats}" "A" "${new_assembly_summary}" >> "${new_output_prefix}${timestamp}_sequence_accession.txt"
+                echolog " - ${new_output_prefix}${timestamp}_sequence_accession.txt" "1"
+                echolog "" "1"
             fi
         fi
         # Remove update files

--- a/tests/integration_offline.bats
+++ b/tests/integration_offline.bats
@@ -368,9 +368,8 @@ setup_file() {
     sanity_check ${outdir} ${label}
 
     # Check if report was printed and has all lines reported
-    report_file="${outdir}${label}/updated_assembly_accession.txt"
-    assert_file_exist "${report_file}"
-    assert_equal $(count_lines_file "${report_file}") $(count_lines_file ${outdir}assembly_summary.txt)
+    assert_file_exist ${outdir}${label}/*_assembly_accession.txt
+    assert_equal $(count_lines_file ${outdir}${label}/*_assembly_accession.txt) $(count_lines_file ${outdir}assembly_summary.txt)
 }
 
 @test "Report sequence accession" {
@@ -380,8 +379,7 @@ setup_file() {
     sanity_check ${outdir} ${label}
 
     # Check if report was printed
-    report_file="${outdir}${label}/updated_sequence_accession.txt"
-    assert_file_exist "${report_file}"
+    assert_file_exist ${outdir}${label}/*_sequence_accession.txt
 }
 
 @test "Report urls" {
@@ -606,8 +604,7 @@ setup_file() {
     run ./genome_updater.sh -o ${outdir} -b ${label} -g "" -d refseq,genbank -u
     sanity_check ${outdir} ${label}
 
-    report_file="${outdir}${label}/updated_assembly_accession.txt"
-    assert_file_exist "${report_file}"
+    assert_file_exist ${outdir}${label}/*_assembly_accession.txt
 
     # Check log for updates
     grep "0 updated, [1-9][0-9]* removed, [1-9][0-9]* new entries" ${outdir}${label}/*.log # >&3


### PR DESCRIPTION
Sequence and assembly accession reports are now written under the run timestamp. That way it's possible to track all actions on files.