### PR TITLE
feat: add -H flag to use hard links instead of symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ When updating an existing local repository:
 
  - Newly added sequences will be downloaded, creating a new version (`-b`, timestamp by default).
  - Removed or old sequences will be retained, but not transferred to the new version.
- - Repeated/unchanged files are linked to the new version (symbolic links by default, or hard links with `-H`).
- - The `-H` flag can be used to create hard links instead of symbolic links. This is particularly useful on HPC systems to save inodes, as hard links point to the same disk data without consuming additional inodes. Note that hard links only work when the working directory and target files are on the same filesystem.
+ - Repeated/unchanged files are linked to the new version (hard links by default, or soft links with `-H soft`).
+ - The `-H` parameter can be used to set the link mode (`hard` or `soft`). Hard links are the default and are particularly useful on HPC systems to save inodes, as they point to the same disk data without consuming additional inodes. Note that hard links only work when the working directory and target files are on the same filesystem. Use `-H soft` for symbolic links.
  - Arguments can be added to or changed in the update. For example, use the command `./genome_updater.sh -o "arc_refseq_cg" -t 2` to specify a different number of threads, or use the command `./genome_updater.sh -o "arc_refseq_cg" -l ""` to remove the `complete genome` filter.
  - The file `history.tsv` will be created in the output folder (`-o`), tracking the versions and arguments used. Please note that boolean flags/arguments are not tracked (e.g. `-m`).
 
@@ -365,7 +365,8 @@ Run options:
  -k Dry-run mode. No sequence data is downloaded or updated - just checks for available sequences and changes
  -i Fix only mode. Re-downloads incomplete or failed data from a previous run. Can also be used to change files (-f).
  -m Check MD5 of downloaded files
- -H Use hard links instead of symbolic links when updating a repository. Useful if you have restrictions on the number of files (inodes). Note: both the previous and new output directories must be on the same filesystem'
+ -H Link mode. [hard, soft]. Hard links save inodes (useful on HPC systems), but only work if both previous and new output directories are on the same filesystem.
+        Default: "hard"
 
 Report options:
  -u Updated assembly accessions report

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ When updating an existing local repository:
 
  - Newly added sequences will be downloaded, creating a new version (`-b`, timestamp by default).
  - Removed or old sequences will be retained, but not transferred to the new version.
- - Repeated/unchanged files are linked to the new version.
+ - Repeated/unchanged files are linked to the new version (symbolic links by default, or hard links with `-H`).
+ - The `-H` flag can be used to create hard links instead of symbolic links. This is particularly useful on HPC systems to save inodes, as hard links point to the same disk data without consuming additional inodes. Note that hard links only work when the working directory and target files are on the same filesystem.
  - Arguments can be added to or changed in the update. For example, use the command `./genome_updater.sh -o "arc_refseq_cg" -t 2` to specify a different number of threads, or use the command `./genome_updater.sh -o "arc_refseq_cg" -l ""` to remove the `complete genome` filter.
  - The file `history.tsv` will be created in the output folder (`-o`), tracking the versions and arguments used. Please note that boolean flags/arguments are not tracked (e.g. `-m`).
 
@@ -364,6 +365,7 @@ Run options:
  -k Dry-run mode. No sequence data is downloaded or updated - just checks for available sequences and changes
  -i Fix only mode. Re-downloads incomplete or failed data from a previous run. Can also be used to change files (-f).
  -m Check MD5 of downloaded files
+ -H Use hard links instead of symbolic links when updating a repository. Useful if you have restrictions on the number of files (inodes). Note: both the previous and new output directories must be on the same filesystem'
 
 Report options:
  -u Updated assembly accessions report

--- a/genome_updater.sh
+++ b/genome_updater.sh
@@ -763,7 +763,7 @@ remove_files() # parameter: ${1} file, ${2} fields [assembly_accesion,url] OR fi
     deleted_files=0
     while read -r f; do
         path_name="${target_output_prefix}$(path_output "${f}")${f}"
-        # check hard link count.
+        # check hard link count: GNU stat: -c '%h' / BSD stat: -f '%l'
         hl_count=$(stat -c '%h' "${path_name}" 2>/dev/null || stat -f '%l' "${path_name}" 2>/dev/null || echo 1)
 
         # Only delete if delete option is enable or if it's a symbolic link (from updates)

--- a/genome_updater.sh
+++ b/genome_updater.sh
@@ -115,7 +115,11 @@ link_version() # parameter: ${1} current_output_prefix, ${2} new_output_prefix, 
     path_out=$(path_output "${3}")
     if [[ -f "${1}${path_out}${3}" ]]; then
         mkdir -p "${2}${path_out}";
-        ln -s -r "${1}${path_out}${3}" "${2}${path_out}";
+        if [[ "${hard_links}" -eq 1 ]]; then
+            ln "${1}${path_out}${3}" "${2}${path_out}";
+        else
+            ln -s -r "${1}${path_out}${3}" "${2}${path_out}";
+        fi
     fi
 }
 export -f link_version  #export it to be accessible to the parallel call
@@ -759,8 +763,11 @@ remove_files() # parameter: ${1} file, ${2} fields [assembly_accesion,url] OR fi
     deleted_files=0
     while read -r f; do
         path_name="${target_output_prefix}$(path_output "${f}")${f}"
+        # check hard link count.
+        hl_count=$(stat -c '%h' "${path_name}" 2>/dev/null || stat -f '%l' "${path_name}" 2>/dev/null || echo 1)
+
         # Only delete if delete option is enable or if it's a symbolic link (from updates)
-        if [[ -L "${path_name}" || "${delete_extra_files}" -eq 1 ]]; then
+        if [[ -L "${path_name}" || "${delete_extra_files}" -eq 1 || "${hl_count}" -gt 1 ]]; then
             rm "${path_name}" -v >> "${log_file}"
             deleted_files=$((deleted_files + 1))
         else
@@ -890,6 +897,7 @@ function showhelp {
     echo $' -k Dry-run mode. No sequence data is downloaded or updated - just checks for available sequences and changes'
     echo $' -i Fix only mode. Re-downloads incomplete or failed data from a previous run. Can also be used to change files (-f).'
     echo $' -m Check MD5 of downloaded files'
+    echo $' -H Use hard links instead of symbolic links when updating a repository. Useful if you have restrictions on the number of files (inodes). Note: both the previous and new output directories must be on the same filesystem'
     echo
     echo $'Report options:'
     echo $' -u Updated assembly accessions report\n\t(Added/Removed, assembly accession, url)'
@@ -926,6 +934,7 @@ date_end=""
 tax_mode="ncbi"
 download_taxonomy=0
 delete_extra_files=0
+hard_links=0
 check_md5=0
 updated_assembly_accession=0
 updated_sequence_accession=0
@@ -959,7 +968,7 @@ done
 if [ "${tool_not_found}" -eq 1 ]; then exit 1; fi
 
 # Parse -o and -B first to detect possible updates
-getopts_list="aA:b:B:c:d:D:e:E:f:F:g:hikl:L:mM:n:No:prR:st:T:uVwxZ"
+getopts_list="aA:b:B:c:d:D:e:E:f:F:g:hHikl:L:mM:n:No:prR:st:T:uVwxZ"
 OPTIND=1 # Reset getopts
 # Parses working_dir from "$@"
 while getopts "${getopts_list}" opt; do
@@ -1018,6 +1027,7 @@ while getopts "${getopts_list}" opt "${args[@]}"; do
     F) custom_filter=${OPTARG} ;;
     g) organism_group=${OPTARG// } ;; #remove spaces
     h) showhelp; exit 0 ;;
+    H) hard_links=1 ;;
     i) just_fix=1 ;;
     k) dry_run=1 ;;
     l) assembly_level=${OPTARG} ;;
@@ -1213,7 +1223,7 @@ elif [ "${silent_progress}" -eq 1 ] ; then
 fi
 n_formats=$(echo "${file_formats}" | tr -cd , | wc -c) # number of file formats
 timestamp=$(date +%Y-%m-%d_%H-%M-%S) # timestamp of the run
-export check_md5 silent silent_progress n_formats timestamp verbose_log # To be accessible in functions called by parallel
+export check_md5 silent silent_progress n_formats timestamp verbose_log hard_links # To be accessible in functions called by parallel
 
 # Create working directory
 if [[ -z "${working_dir}" ]]; then

--- a/genome_updater.sh
+++ b/genome_updater.sh
@@ -115,7 +115,7 @@ link_version() # parameter: ${1} current_output_prefix, ${2} new_output_prefix, 
     path_out=$(path_output "${3}")
     if [[ -f "${1}${path_out}${3}" ]]; then
         mkdir -p "${2}${path_out}";
-        if [[ "${hard_links}" -eq 1 ]]; then
+        if [[ "${link_mode}" == "hard" ]]; then
             ln "${1}${path_out}${3}" "${2}${path_out}";
         else
             ln -s -r "${1}${path_out}${3}" "${2}${path_out}";
@@ -767,7 +767,7 @@ remove_files() # parameter: ${1} file, ${2} fields [assembly_accesion,url] OR fi
         hl_count=$(stat -c '%h' "${path_name}" 2>/dev/null || stat -f '%l' "${path_name}" 2>/dev/null || echo 1)
 
         # Only delete if delete option is enable or if it's a symbolic link (from updates)
-        if [[ -L "${path_name}" || "${delete_extra_files}" -eq 1 || "${hl_count}" -gt 1 ]]; then
+        if [[ -L "${path_name}" || "${delete_extra_files}" -eq 1 || ( "${link_mode}" == "hard" && "${hl_count}" -gt 1 ) ]]; then
             rm "${path_name}" -v >> "${log_file}"
             deleted_files=$((deleted_files + 1))
         else
@@ -897,7 +897,7 @@ function showhelp {
     echo $' -k Dry-run mode. No sequence data is downloaded or updated - just checks for available sequences and changes'
     echo $' -i Fix only mode. Re-downloads incomplete or failed data from a previous run. Can also be used to change files (-f).'
     echo $' -m Check MD5 of downloaded files'
-    echo $' -H Use hard links instead of symbolic links when updating a repository. Useful if you have restrictions on the number of files (inodes). Note: both the previous and new output directories must be on the same filesystem'
+    echo $' -H Link mode. [hard, soft]. Hard links save inodes (i.e. number of files; useful on HPC systems), but only work if both previous and new output directories are on the same filesystem.\n\tDefault: "hard"'
     echo
     echo $'Report options:'
     echo $' -u Updated assembly accessions report\n\t(Added/Removed, assembly accession, url)'
@@ -934,7 +934,7 @@ date_end=""
 tax_mode="ncbi"
 download_taxonomy=0
 delete_extra_files=0
-hard_links=0
+link_mode="hard"
 check_md5=0
 updated_assembly_accession=0
 updated_sequence_accession=0
@@ -968,7 +968,7 @@ done
 if [ "${tool_not_found}" -eq 1 ]; then exit 1; fi
 
 # Parse -o and -B first to detect possible updates
-getopts_list="aA:b:B:c:d:D:e:E:f:F:g:hHikl:L:mM:n:No:prR:st:T:uVwxZ"
+getopts_list="aA:b:B:c:d:D:e:E:f:F:g:hH:ikl:L:mM:n:No:prR:st:T:uVwxZ"
 OPTIND=1 # Reset getopts
 # Parses working_dir from "$@"
 while getopts "${getopts_list}" opt; do
@@ -1027,7 +1027,7 @@ while getopts "${getopts_list}" opt "${args[@]}"; do
     F) custom_filter=${OPTARG} ;;
     g) organism_group=${OPTARG// } ;; #remove spaces
     h) showhelp; exit 0 ;;
-    H) hard_links=1 ;;
+    H) link_mode=${OPTARG} ;;
     i) just_fix=1 ;;
     k) dry_run=1 ;;
     l) assembly_level=${OPTARG} ;;
@@ -1099,6 +1099,10 @@ fi
 
 if [[ ! "${file_formats}" =~ assembly_report.txt && "${updated_sequence_accession}" -eq 1 ]]; then
     echo "Updated sequence accessions report (-r) can only be used if -f contains 'assembly_report.txt'"; exit 1;
+fi
+
+if [[ "${link_mode}" != "hard" && "${link_mode}" != "soft" ]]; then
+    echo "${link_mode}: invalid link mode [hard, soft]"; exit 1;
 fi
 
 if [[ -z "${database}" && -z "${external_assembly_summary}" ]]; then
@@ -1223,7 +1227,7 @@ elif [ "${silent_progress}" -eq 1 ] ; then
 fi
 n_formats=$(echo "${file_formats}" | tr -cd , | wc -c) # number of file formats
 timestamp=$(date +%Y-%m-%d_%H-%M-%S) # timestamp of the run
-export check_md5 silent silent_progress n_formats timestamp verbose_log hard_links # To be accessible in functions called by parallel
+export check_md5 silent silent_progress n_formats timestamp verbose_log link_mode # To be accessible in functions called by parallel
 
 # Create working directory
 if [[ -z "${working_dir}" ]]; then


### PR DESCRIPTION
Adds the `-H` option to use hard links (`ln`) instead of symbolic links (`ln -s`) when updating a repository and linking existing files to a new datestamped directory. 

This prevents inode exhaustion on HPC systems when updating large databases, as hard links point to the existing data and do not consume additional inodes. It also allows for seamless copying to compute nodes without needing to dereference symlinks.

A bit of background: I've run into a significant bottleneck when running `genome_updater.sh` a second time to check for missing or updated files on our institutional HPC cluster. When `genome_updater` creates a new datestamped directory for the updated run, it leaves the previously downloaded files in their original folder and creates symbolic links for every file it already had. In my recent run to grab 14,341 new/fixed files, the tool generated 3,414,730 symbolic links.

On some HPC systems, storage quotas are often dictated by number of files (inodes), as well as file size. Because every symbolic link requires a brand new inode, generating 3.4 million symlinks instantly triggered our group's inode limits.

I then ran into a secondary issue: When shovelling all these downloads over to compute-node local storage ($TMPDIR) for processing, standard copy commands just copy the symlinks rather than resolving them. I only realised this when my downstream pipeline failed because the millions of actual files were still sitting in the old directory, not the current datestamped folder.

I hope this feature is in scope and that my implementation is acceptable? Happy to make any other changes you would like. And, of course, feel free to decline the update if you don't want it.